### PR TITLE
update sbt to 1.1.1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.1


### PR DESCRIPTION
This fixes an issue in sbt assembly on windows, where no fat jar would be built if part of the path does not yet exist.